### PR TITLE
Add error message when "crypt.exe" is missing

### DIFF
--- a/host.py
+++ b/host.py
@@ -1,10 +1,12 @@
 import subprocess, os, socket, requests
 
+crypt_path = 'crypt.exe'
+
 if os.path.basename(__file__) == "host.py":
-    keys_call = subprocess.run(['crypt.exe', 'generate_key'], capture_output=True)
+    keys_call = subprocess.run([crypt_path, 'generate_key'], capture_output=True)
     key = keys_call.stdout.decode('utf-8')
 else:
-    print('"crypt.exe" not found')
+    print(f'"{crypt_path}" not found')
     exit(1)
 
 server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/host.py
+++ b/host.py
@@ -4,6 +4,7 @@ if os.path.basename(__file__) == "host.py":
     keys_call = subprocess.run(['crypt.exe', 'generate_key'], capture_output=True)
     key = keys_call.stdout.decode('utf-8')
 else:
+    print('"crypt.exe" not found')
     exit(1)
 
 server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
I suppose this file should not be public for now, or the user has to manually pick a version from the `cpp_build` folder.
if so, tell me and I'll update the message (or you after merging).